### PR TITLE
侧边栏 rail 改用钱包图标(官方填充式 SVG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件按 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 格式维护。
 
+## [Unreleased]
+
+### 变更
+
+- 侧边栏 rail 模式:余额行与今日行的文本符号(¥)改为官方风格钱包图标(16×16 填充式 SVG,currentColor,跟随主题色);宽栏文案、悬停明细与错误态(⚠)不变。
+
 ## [1.2.0] - 2026-08-14
 
 ### 新增

--- a/lib/client.js
+++ b/lib/client.js
@@ -734,6 +734,19 @@ window.__ModuleLoader__.load({
 
     const { createElement: el, Fragment, useState, useEffect, useMemo, useCallback } = React
 
+    // ── 钱包图标:官方填充式单色 SVG(16×16),与 @deepseek-ai/dsh-client-ui-primitives 同构 ──
+
+    function WalletIcon({ size = 16, className }) {
+      return el('svg', { width: size, height: size, className, viewBox: '0 0 16 16', fill: 'none', xmlns: 'http://www.w3.org/2000/svg' },
+        el('path', {
+          d: 'M4 4H12A2 2 0 0 1 14 6V11.5A2 2 0 0 1 12 13.5H4A2 2 0 0 1 2 11.5V6A2 2 0 0 1 4 4ZM4 5.3H12A0.7 0.7 0 0 1 12.7 6V11.5A0.7 0.7 0 0 1 12 12.2H4A0.7 0.7 0 0 1 3.3 11.5V6A0.7 0.7 0 0 1 4 5.3Z',
+          fill: 'currentColor',
+          fillRule: 'evenodd',
+        }),
+        el('path', { d: 'M3.3 5.3H12.7V7.1H3.3Z', fill: 'currentColor' }),
+        el('path', { d: 'M8 2.8A1.3 1.3 0 1 0 8 5.4A1.3 1.3 0 1 0 8 2.8Z', fill: 'currentColor' }))
+    }
+
     // ── 会话费用徽章(dock / header) ────────────────────────────────────────
 
     function SessionCost(props) {
@@ -809,7 +822,7 @@ window.__ModuleLoader__.load({
       ].join('; ')
       return el(Tooltip, { label: detail, side: 'right', delayMs: 300 },
         el('div', { className: 'cm-foot' + (wide ? '' : ' cm-foot-rail') },
-          wide ? el(Fragment, null, t('balance'), ' ', el('span', { className: 'cm-num' }, formatBalanceMoney(balance.totalBalance, state.config))) : (state.config.symbol || '¥')))
+          wide ? el(Fragment, null, t('balance'), ' ', el('span', { className: 'cm-num' }, formatBalanceMoney(balance.totalBalance, state.config))) : el(WalletIcon, { size: 16 })))
     }
 
     function BudgetBoxContent(props) {
@@ -877,7 +890,7 @@ window.__ModuleLoader__.load({
       ].join('; ')
       return el(Tooltip, { label: detail, side: 'right', delayMs: 300 },
         el('div', { className: 'cm-foot' + (wide ? '' : ' cm-foot-rail') },
-          wide ? el(Fragment, null, t('today'), ' ', el('span', { className: 'cm-num' }, formatMoneyUsd(today.cost, config))) : '¥'))
+          wide ? el(Fragment, null, t('today'), ' ', el('span', { className: 'cm-num' }, formatMoneyUsd(today.cost, config))) : el(WalletIcon, { size: 16 })))
     }
 
     function SidebarFooter(props) {


### PR DESCRIPTION
## 变更

侧边栏 rail 模式下，余额行与今日行此前用文本符号「¥」占位（今日行更是硬编码 ¥、无视配置的货币符号）。本 PR：

- 新增 `WalletIcon`（16×16 填充式 SVG，与官方 `@deepseek-ai/dsh-client-ui-primitives` 图标同构：`fill="currentColor"`，随主题色变化）；
- rail 模式余额行与今日行改用钱包图标；宽栏文案、悬停明细、错误态（⚠）均不变；
- CHANGELOG 增加 `[Unreleased]` 条目。

## 背景

- 设置页「费用」分节的导航图标由外壳 `navIcon(id)` 硬编码（仅 models / agent-presets / plugins 有专属图标，其余回退齿轮），插件侧无法注册图标——所以本 PR 只在插件自己的界面（侧边栏 rail）落地钱包视觉。
- 官方 primitives 图标库共 70 个图标，无钱包/货币类图形；本图标为按官方填充式规范自绘。

## 验证

- `node --check lib/client.js` 语法通过；
- 本地 DSH Web GUI（0.1.0-rc.6）侧边栏 rail 实测渲染正常，图标随主题色变化。

## 说明

- 余额行 rail 原先显示配置的货币符号（¥/$/€），现统一为图标，货币信息仍保留在宽栏与悬停明细中；若希望保留符号显示，仅需回退该行一处改动。