### PR TITLE
fix: default the display currency to USD

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -584,8 +584,8 @@ window.__ModuleLoader__.load({
         locale: v.locale === 'zh' || v.locale === 'en' || v.locale === 'auto' ? v.locale : 'auto',
         position: v.position === 'header' || v.position === 'off' ? v.position : 'dock',
         sidebar: v.sidebar !== false,
-        currency: typeof v.currency === 'string' ? v.currency : 'CNY',
-        symbol: typeof v.symbol === 'string' ? v.symbol : '¥',
+        currency: typeof v.currency === 'string' ? v.currency : 'USD',
+        symbol: typeof v.symbol === 'string' ? v.symbol : '$',
         decimals: needNum(v.decimals, path + '.decimals'),
         exchangeRate: needNum(v.exchangeRate, path + '.exchangeRate'),
         peakEnabled: v.peakEnabled === true,
@@ -1758,7 +1758,7 @@ window.__ModuleLoader__.load({
               el('label', null, t('currencyLabel')),
               el('select', {
                 className: 'cm-input',
-                value: draft?.currency ?? 'CNY',
+                value: draft?.currency ?? 'USD',
                 onChange: event => {
                   const preset = CURRENCY_PRESETS[event.target.value]
                   if (preset !== undefined && draft !== null) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -27,10 +27,10 @@ export function defaultConfig() {
     locale: 'auto', // 界面语言:auto(跟随浏览器) | zh(中文) | en(English)
     position: 'dock', // 会话费用显示位置:dock(输入区下方) | header(会话标题栏) | off
     sidebar: true, // 侧边栏底部显示当日费用
-    currency: 'CNY', // CNY | USD | EUR | custom
-    symbol: '¥',
+    currency: 'USD', // CNY | USD | EUR | custom
+    symbol: '$',
     decimals: 4,
-    exchangeRate: 7.2, // 展示层:美元 → 币种汇率
+    exchangeRate: 1, // 展示层:美元 → 币种汇率
     peakEnabled: true, // 启用峰谷计价
     peakEffectiveAt: DEFAULT_PEAK_EFFECTIVE_AT,
     peakWindows: DEFAULT_PEAK_WINDOWS.map(w => ({ ...w })),


### PR DESCRIPTION
## Summary
Default the display currency to USD (symbol $, rate 1) instead of CNY (¥, 7.2) in both the store schema defaults and the client-side config fallbacks. Users can still switch to CNY/EUR in Display settings.

## PR Type
- [x] Bug 修复 / 面向用户的行为变更

## AI Coding Disclosure
- [x] 部分 AI 辅助 (AI-assisted; reviewed and accepted by the contributor)
- 使用的 AI 模型: DeepSeek (deepseek-v4-flash)
- 使用的编码 Agent 工具: DeepSeek Harness (dsh)

## Local Validation
```
node --check lib/store.js
node --check lib/client.js
```