### PR TITLE
Add wire to costUsage projection for DSH 0.1.1-rc.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .audit-tmp/
 .qoder/
 HANDOFF.md
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 修复
+
+- **dsh 0.1.1-rc.1 下输入区下方的会话费用不再显示**:DSH 0.1.1-rc.1 起,会话投影需声明 `wire`(viewSchema + view)才会向客户端推送——无 `wire` 的投影在快照(snapshot)、变更推送(onChanged)与历史重放(refold)中全部被跳过,导致客户端 `useProjection('costUsage')` 恒为空,`DockLine` 因用量为 0 隐藏。现为 `costUsage` 投影补充 `wire`,复用其 `view` 逻辑与 `usageProjectionSchema` 作为 viewSchema,写法与宿主 `sessionStats` 投影一致。升级前(dsh 0.1.0-rc.7 及更早)投影系统直接推送 state,不受影响。
+
 ## [1.5.33] - 2026-08-21
 
 ### 修复

--- a/lib/index.js
+++ b/lib/index.js
@@ -262,6 +262,22 @@ function makeCostUsageProjection(ledger) {
         byProviderModel: state.byProviderModel,
       }
     },
+    // DSH 0.1.1-rc.1 起会话投影需声明 wire 才会向客户端推送:
+    // 无 wire 的投影在 snapshot/onChanged/refold 中被跳过,客户端
+    // useProjection('costUsage') 恒为空,输入区下方的会话费用随之隐藏。
+    wire: {
+      viewSchema: usageProjectionSchema,
+      view: (state) => ({
+        input: state.totals.input,
+        output: state.totals.output,
+        cacheRead: state.totals.cacheRead,
+        cacheWrite: state.totals.cacheWrite,
+        reasoning: state.totals.reasoning,
+        cost: state.totals.cost,
+        byModel: state.byModel,
+        byProviderModel: state.byProviderModel,
+      }),
+    },
   }
 }
 


### PR DESCRIPTION
## 概述 · Summary

修复 dsh 0.1.1-rc.1 升级后输入区下方"会话费用"不再显示的问题：该版本起会话投影必须声明 `wire`（viewSchema + view）才会向客户端推送，costUsage 投影缺少 `wire` 导致 `useProjection('costUsage')` 恒为空。已为投影补上 `wire` 块，恢复会话费用显示。

## 改动类型 · Type

- [x] Bug 修复

## 改动点 · Changes

- `lib/index.js`：给 `makeCostUsageProjection` 的返回对象补充 `wire` 字段（`viewSchema: usageProjectionSchema` + `view`，复用已有 view 逻辑），与宿主 `sessionStats` 投影写法一致；补丁仅服务端生效，无 UI 截图差异。
- `CHANGELOG.md`：新增 `[Unreleased]` 段说明修复动机与影响范围。