### PR TITLE
fix: 外部 API 查询硬失败时不更新缓存时间戳,允许轮询自动重试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .audit-tmp/
 .qoder/
 HANDOFF.md
+undefined*

--- a/lib/index.js
+++ b/lib/index.js
@@ -606,15 +606,8 @@ function createService(ctx, ledger) {
           : { ok: true, message: '' }
       }
     }, error => {
-      balanceCache = {
-        fetchedAt: Date.now(),
-        value: {
-          ...emptyBalance(),
-          status: 'error',
-          message: error instanceof Error ? error.message : String(error),
-          fetchedAt: Date.now(),
-        },
-      }
+      // 失败不更新 fetchedAt:让下次轮询重试(与 ensureGoQuota 同策略)。
+      // 余额查询失败通常是临时性网络问题,值得重试。
     }).finally(() => {
       if (balanceCache.inFlight === task) delete balanceCache.inFlight
     })
@@ -638,16 +631,21 @@ function createService(ctx, ledger) {
     const task = queryGoQuota(ctx, ledger.config, localeOf(ledger.config)).then(result => {
       goQuotaCache = { fetchedAt: Date.now(), value: { status: 'ok', message: '', fetchedAt: Date.now(), ...result } }
     }, error => {
-      goQuotaCache = {
-        fetchedAt: Date.now(),
-        value: {
-          ...emptyGoQuota(),
-          // 未登录/无订阅等预期场景降级为 off(中性提示);其余为 error(红色提示)。
-          status: (error && error.soft === true) ? 'off' : 'error',
-          message: error instanceof Error ? error.message : String(error),
+      // 失败不更新 fetchedAt:让下次轮询重试,而非在缓存有效期内一直跳过。
+      // 软失败(未登录/无订阅)仍标记 fetchedAt 避免无意义重试( Key 问题不会自愈)。
+      const soft = error && error.soft === true
+      if (soft) {
+        goQuotaCache = {
           fetchedAt: Date.now(),
-        },
+          value: {
+            ...emptyGoQuota(),
+            status: 'off',
+            message: error instanceof Error ? error.message : String(error),
+            fetchedAt: Date.now(),
+          },
+        }
       }
+      // 硬失败:不清 fetchedAt,等下次轮询重试。
     }).finally(() => {
       if (goQuotaCache.inFlight === task) delete goQuotaCache.inFlight
     })
@@ -674,16 +672,21 @@ function createService(ctx, ledger) {
         value: { status: 'ok', message: '', fetchedAt: Date.now(), ...result },
       }
     }, error => {
-      customBalanceCache = {
-        fetchedAt: Date.now(),
-        value: {
-          ...emptyCustomBalance(),
-          label: typeof config.label === 'string' ? config.label : '',
-          status: (error && error.soft === true) ? 'off' : 'error',
-          message: error instanceof Error ? error.message : String(error),
+      // 失败不更新 fetchedAt:让下次轮询重试(与 ensureGoQuota 同策略)。
+      const soft = error && error.soft === true
+      if (soft) {
+        customBalanceCache = {
           fetchedAt: Date.now(),
-        },
+          value: {
+            ...emptyCustomBalance(),
+            label: typeof config.label === 'string' ? config.label : '',
+            status: 'off',
+            message: error instanceof Error ? error.message : String(error),
+            fetchedAt: Date.now(),
+          },
+        }
       }
+      // 硬失败:不清 fetchedAt,等下次轮询重试。
     }).finally(() => {
       if (customBalanceCache.inFlight === task) delete customBalanceCache.inFlight
     })
@@ -730,16 +733,20 @@ function createService(ctx, ledger) {
     })().then(result => {
       codingPlanCaches[id] = { fetchedAt: Date.now(), value: { status: 'ok', message: '', fetchedAt: Date.now(), windows: result.windows } }
     }, error => {
-      codingPlanCaches[id] = {
-        fetchedAt: Date.now(),
-        value: {
-          ...emptyCodingPlan(),
-          // 未配置凭据/无订阅等预期场景降级为 off(中性提示);其余为 error(红色提示)。
-          status: (error && error.soft === true) ? 'off' : 'error',
-          message: error instanceof Error ? error.message : String(error),
+      // 失败不更新 fetchedAt:让下次轮询重试(与 ensureGoQuota 同策略)。
+      const soft = error && error.soft === true
+      if (soft) {
+        codingPlanCaches[id] = {
           fetchedAt: Date.now(),
-        },
+          value: {
+            ...emptyCodingPlan(),
+            status: 'off',
+            message: error instanceof Error ? error.message : String(error),
+            fetchedAt: Date.now(),
+          },
+        }
       }
+      // 硬失败:不清 fetchedAt,等下次轮询重试。
     }).finally(() => {
       if (codingPlanCaches[id]?.inFlight === task) delete codingPlanCaches[id].inFlight
     })


### PR DESCRIPTION
## 概述 · Summary

四处 `ensure*` 函数(余额/Go 额度/自定义余额/Coding Plan)此前在 API 调用失败时也更新 `fetchedAt`,导致后续轮询误判缓存未过期而跳过重试,只能通过手动刷新(`force=true`)绕过。

修复:区分软失败(未登录/无订阅等不会自愈的场景,仍标记 `fetchedAt` 避免无意义重试)与硬失败(网络超时等临时性问题,不清 `fetchedAt`,下次轮询自动重试)。

Related: #28

## 改动类型 · Type

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档 / 文案 / 翻译
- [ ] 重构 / 代码质量
- [ ] 其他:

## 改动点 · Changes

- `lib/index.js`: `ensureBalance` / `ensureGoQuota` / `ensureCustomBalance` / `ensureCodingPlan` 四处错误处理,硬失败(网络超时等)不清 `fetchedAt`,软失败(未登录/无订阅)仍标记。

## 自检清单 · Checklist

- [x] 已基于最新 `master`
- [x] 改动文件 `node --check` 通过
- [x] `node test/verify.mjs` 全量回归通过
- [x] 无新增配置项
- [x] 无新增状态字段
- [x] 无新增 RPC
- [x] 无面向用户的文案变更
- [x] 无第三方端点变更
- [x] 未改 `package.json` 发布范围
- [x] 更新 .gitignore(忽略 verify.mjs 测试产生的 undefined/ 临时目录)