### PR TITLE
fix: 启动期历史回填全量读取大会话日志导致 dsh web 启动 OOM (#50)

### DIFF
--- a/lib/backfill.js
+++ b/lib/backfill.js
@@ -72,35 +72,62 @@ export function scanZstdFrames(buffer) {
 
 /**
  * 读取一份会话日志的全部事件行(zstd 逐 frame 解压;明文直接按行)。
+ *
+ * 内存约束:宿主会话日志可含数万帧(每次追加批次一个独立 zstd frame,
+ * 长期会话可达 10 万+ 帧)且解压后数百 MB。旧实现把所有帧一次性解压、
+ * Buffer.concat 拼成全文再 split——峰值内存可达数 GB,4GB 堆限制下
+ * 会 OOM(实测一份 50MB / 11.5 万帧日志即 ~3GB)。现改为逐帧解压、
+ * 逐帧按行切片解析:任一时刻只保留单帧解压结果(通常 ≤ 数 MB),行缓冲
+ * 跨帧拼接兜底半行(追加批次以换行结尾,实际不会出现)。
  * @param path - session.jsonl.zstd 或 session.jsonl 路径。
  * @returns 逐行 JSON.parse 后的记录数组(坏行跳过)。
  */
 export function readSessionRecords(path) {
   const buffer = readFileSync(path)
-  let text
+  const records = []
+  let pending = '' // 跨帧行缓冲:上一帧末尾未换行的残行拼接进下一帧首行。
+  const consumeText = (text) => {
+    if (text.length === 0) return
+    const lines = text.split('\n')
+    lines[0] = pending + lines[0]
+    pending = lines[lines.length - 1]
+    for (let i = 0; i < lines.length - 1; i++) {
+      const line = lines[i]
+      if (line.length === 0) continue
+      try {
+        records.push(JSON.parse(line))
+      } catch {
+        // 坏行跳过:回放是尽力而为,不让单行损坏阻断整个会话。
+      }
+    }
+  }
   if (path.endsWith('.zstd')) {
     if (typeof zlib.zstdDecompressSync !== 'function') return []
     const frames = scanZstdFrames(buffer)
-    if (frames.length === 0) return []
-    const parts = frames.map(f => zlib.zstdDecompressSync(buffer.subarray(f.start, f.end)))
-    text = Buffer.concat(parts).toString('utf8')
+    for (const f of frames) {
+      consumeText(zlib.zstdDecompressSync(buffer.subarray(f.start, f.end)).toString('utf8'))
+    }
   } else {
-    text = buffer.toString('utf8')
+    consumeText(buffer.toString('utf8'))
   }
-  const records = []
-  for (const line of text.split('\n')) {
-    if (line.length === 0) continue
+  if (pending.length > 0) {
     try {
-      records.push(JSON.parse(line))
+      records.push(JSON.parse(pending))
     } catch {
-      // 坏行跳过:回放是尽力而为,不让单行损坏阻断整个会话。
+      // 文件末尾无换行的残行:同上,尽力而为。
     }
   }
   return records
 }
 
-/** 枚举会话根目录下全部会话日志路径(<root>/<项目>/<会话>/session.jsonl[.zstd])。 */
-export function listSessionLogs(root) {
+/**
+ * 枚举会话根目录下全部会话日志路径(<root>/<项目>/<会话>/session.jsonl[.zstd])。
+ * @param root - 会话根目录。
+ * @param onlySessionIds - 可选:仅枚举这些会话目录(Set<会话 id>)。纯标题/时间戳
+ *   补齐时按缺失会话定向,避免为补齐一两个标题全量读取全部会话日志(其中可能
+ *   含解压后数百 MB 的大文件)。null = 全部。
+ */
+export function listSessionLogs(root, onlySessionIds = null) {
   const paths = []
   let projects
   try {
@@ -118,6 +145,7 @@ export function listSessionLogs(root) {
     }
     for (const session of sessions) {
       if (!session.isDirectory()) continue
+      if (onlySessionIds !== null && !onlySessionIds.has(session.name)) continue
       for (const name of ['session.jsonl.zstd', 'session.jsonl']) {
         const path = join(root, project.name, session.name, name)
         try {
@@ -314,7 +342,22 @@ export async function backfillLegacyLedger(ledger, sessionsRoot) {
   const titles = new Map()
   const createdAts = new Map()
   let scannedCount = 0
-  for (const path of listSessionLogs(sessionsRoot)) {
+  // 纯标题/时间戳补齐(日期级不缺):按缺失会话的 id 定向定位日志文件,绝不
+  // 全量扫描——活跃会话的标题要到下次启动才写入账本,全量扫描会让每次启动
+  // 都重复读全部会话日志(含解压后数百 MB 的大文件,内存峰值几 GB)。
+  let onlySessionIds = null
+  if (needDates.size === 0) {
+    onlySessionIds = new Set()
+    for (const day of Object.values(ledger.days ?? {})) {
+      for (const session of day?.sessions ?? []) {
+        if (session === null || typeof session !== 'object' || typeof session.id !== 'string') continue
+        const missingTitle = typeof session.title !== 'string' || session.title.length === 0
+        const missingAt = !Number.isFinite(Number(session.at))
+        if (missingTitle || missingAt) onlySessionIds.add(session.id)
+      }
+    }
+  }
+  for (const path of listSessionLogs(sessionsRoot, onlySessionIds)) {
     // 会话日志多时逐份解压会长时间占住事件循环:每 8 份让出一次,不卡宿主 UI。
     if ((scannedCount += 1) % 8 === 0) await new Promise(resolve => setImmediate(resolve))
     result.scanned += 1


### PR DESCRIPTION
Fixes #50

## 背景

`dsh web` 启动后约 20 秒内 V8 堆耗尽崩溃（4GB 限制）。根因链：

1. **`readSessionRecords` 单文件峰值 ~3GB**：宿主会话日志每次追加批次写一个独立 zstd frame，长期会话可达 10 万+ 帧；旧实现把所有帧一次性解压（`frames.map(...)`）→ `Buffer.concat` → 整份 `split('\n')` → 全量 `JSON.parse`。实测单份 50MB / **115,358 帧**日志：帧解压阶段已 2254MB，全流程峰值 **2969MB**。
2. **每次启动都全量扫描**：活跃会话的 `session/title` 事件在回填之后才写入日志 → 账本恒缺一个标题 → `needTitles` 恒真 → 每次启动重扫全部会话日志（163 份，含多份解压后数百 MB 的大文件）。

## 改动（`lib/backfill.js`，3 处）

1. **`readSessionRecords` 逐帧流式**：逐帧解压、逐帧按行切片解析，行缓冲跨帧拼接（追加批次以换行结尾，实际不会出现半行）。任一时刻只保留单帧结果；
2. **`listSessionLogs(root, onlySessionIds = null)`**：按会话 id 定向枚举，默认参数向后兼容；
3. **`backfillLegacyLedger` 纯标题/时间戳补齐模式定向扫描**：`needDates` 为空时按缺失会话 id 只读对应日志；日期级缺失仍走全量，行为不变。

## 验证

- 单份 50MB / 115,358 帧日志：峰值 **2969MB → 749MB**，耗时 2022ms → 1713ms，解析 189,821 行一致；
- 真实账本回填：扫描 **163 → 1**（缺失标题会话仅 322KB），标题补齐，calls 总量不变（无重复计数）；
- `node test/verify.mjs` 全量回归 **全部通过**（backfill 幂等/标题补齐/重算、e2e、启动期导入等）。
