### PR TITLE
feat: slider for OpenCode Go quota refresh interval

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,6 +128,9 @@ window.__ModuleLoader__.load({
       '.cm-input{font:inherit;font-size:13px;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-base);border:1px solid var(--dsw-alias-border-l1);border-radius:8px;padding:6px 10px;outline:none}',
       '.cm-input:focus{border-color:var(--dsw-alias-state-business-primary)}',
       '.cm-input.narrow{max-width:120px}',
+      '.cm-range-row{display:flex;align-items:center;gap:10px}',
+      '.cm-range{flex:1;min-width:0;accent-color:var(--dsw-alias-state-business-primary)}',
+      '.cm-range-value{flex:none;min-width:44px;font-size:12px;color:var(--dsw-alias-label-tertiary);text-align:right}',
       '.cm-check{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--dsw-alias-label-primary);cursor:pointer}',
       '.cm-price-card{border:1px solid var(--dsw-alias-border-l1);border-radius:10px;padding:12px 14px;display:flex;flex-direction:column;gap:10px;background:var(--dsw-alias-bg-layer-1)}',
       '.cm-price-head{display:flex;align-items:center;justify-content:space-between;gap:8px}',
@@ -444,6 +447,7 @@ window.__ModuleLoader__.load({
         goQuotaFetchedAt: '更新于 {time}',
         goQuotaDisplayLabel: 'Go 额度显示位置',
         goQuotaRefreshIntervalLabel: 'Go 额度刷新间隔(分钟)',
+        goQuotaRefreshMinutesUnit: '分钟',
         goQuotaKeyLabel: 'OpenCode Go API Key(可选,留空自动发现)',
         goMainLabel: 'Go 额度主档位',
         goDetailLabel: 'Go 图框详细信息',
@@ -841,6 +845,7 @@ window.__ModuleLoader__.load({
         goQuotaFetchedAt: 'Updated {time}',
         goQuotaDisplayLabel: 'Go quota display position',
         goQuotaRefreshIntervalLabel: 'Go quota refresh interval (minutes)',
+        goQuotaRefreshMinutesUnit: 'min',
         goQuotaKeyLabel: 'OpenCode Go API key (optional; empty = auto-detect)',
         goMainLabel: 'Go quota primary window',
         goDetailLabel: 'Go box details',
@@ -5502,10 +5507,18 @@ window.__ModuleLoader__.load({
                 el('option', { value: 'monthly' }, t('goWindowMonthly')))),
             el('div', { className: 'cm-field' },
               el('label', null, t('goQuotaRefreshIntervalLabel')),
-              numInput({ value: draft?.goQuota?.refreshMinutes ?? 15 }, v => {
-                if (draft === null) return
-                setDraft({ ...draft, goQuota: { ...(draft.goQuota ?? { display: 'both', refreshMinutes: 15, apiKey: '' }), refreshMinutes: Math.min(1440, Math.max(1, Math.floor(v))) } })
-              })),
+              el('div', { className: 'cm-range-row' },
+                el('input', {
+                  className: 'cm-range',
+                  type: 'range', min: '1', max: '60', step: '1',
+                  value: Math.min(60, Math.max(1, Math.floor(Number(draft?.goQuota?.refreshMinutes) || 15))),
+                  onChange: event => {
+                    if (draft === null) return
+                    setDraft({ ...draft, goQuota: { ...(draft.goQuota ?? { display: 'both', refreshMinutes: 15, apiKey: '' }), refreshMinutes: Math.min(60, Math.max(1, Math.floor(Number(event.target.value) || 15))) } })
+                  },
+                }),
+                el('span', { className: 'cm-range-value' },
+                  `${Math.min(60, Math.max(1, Math.floor(Number(draft?.goQuota?.refreshMinutes) || 15)))} ${t('goQuotaRefreshMinutesUnit')}`))),
             el('div', { className: 'cm-field' },
               el('label', null, t('goQuotaKeyLabel')),
               el('input', {


### PR DESCRIPTION
## What

Replaces the **OpenCode Go quota refresh interval** number input in the Cost settings panel with a **range slider** (1–60 min, step 1) plus a live "N 分钟 / N min" label, so the interval can be picked freely by dragging.

## Why

The Go quota refresh interval previously was a bare `numInput` box. A slider makes choosing an auto-refresh cadence (e.g. 5 min for frequent quota checks vs 30–60 min for casual use) faster and more visual.

## Changes (all in `lib/client.js`)

- **控件**: swap `numInput` → `<input type="range" min=1 max=60 step=1>` + current-value `<span>` in the 费用设置 → Go 额度 section
- **Styles**: add `.cm-range-row` / `.cm-range` / `.cm-range-value` classes (row + accent-colored track + value text), consistent with existing `cm-field`/`cm-input` look
- **i18n**: add `goQuotaRefreshMinutesUnit` ("分钟" / "min") to the zh/en dictionaries

## Notes

- Range limits are UI-only (1–60); the persisted value clamping (`Math.min(60, Math.max(1, …))` on write) and the host-side 1–1440 validation, query interval, and cache logic are untouched.
- Only the Go quota field changes; balance / custom-balance refresh intervals keep their number inputs.