### PR TITLE
fix(gateway): CLIProxyAPI 网关额度刷新对暂态 HTTP 失败增加重试，消除时好时坏

### DIFF
--- a/lib/gateway-quota-adapters.js
+++ b/lib/gateway-quota-adapters.js
@@ -403,8 +403,8 @@ function codexWindowMeta(seconds) {
     ? seconds
     : typeof seconds === 'string' && seconds.trim() !== '' ? Number(seconds.trim()) : NaN
   if (!Number.isFinite(value) || value <= 0) return null
-  if (value === FIVE_HOUR_SECONDS) return { id: 'five-hour', label: '5 小时', periodHours: 5 }
-  if (value === WEEK_SECONDS) return { id: 'weekly', label: '每周', periodHours: 168 }
+  if (value === FIVE_HOUR_SECONDS) return { id: 'five-hour', label: '5h', periodHours: 5 }
+  if (value === WEEK_SECONDS) return { id: 'weekly', label: '周', periodHours: 168 }
   if (value >= MIN_MONTH_SECONDS && value <= MAX_MONTH_SECONDS) {
     return { id: 'monthly', label: '月度', periodHours: Math.round(value / 3600) }
   }
@@ -453,15 +453,16 @@ export function parseCodexUsage(payload, ctx = {}) {
     const resetAt = absoluteResetAt(pickField(window, 'reset_at', 'resetAt'))
       || relativeResetAt(pickField(window, 'reset_after_seconds', 'resetAfterSeconds'), now())
     seen.add(id)
-    windows.push(makeWindow(id, `${groupLabel} · ${meta.label}`, percent, resetAt, meta.periodHours, scope))
+    // 组标签为空时直接用窗口标签(主限额组不叠加前缀,窄栏标签列放不下会竖排换行)。
+    windows.push(makeWindow(id, groupLabel ? `${groupLabel} · ${meta.label}` : meta.label, percent, resetAt, meta.periodHours, scope))
   }
 
   const source = payload === null || typeof payload !== 'object' ? {} : payload
 
   const mainGroup = pickField(source, 'rate_limit', 'rateLimit')
   if (mainGroup !== null && typeof mainGroup === 'object' && !Array.isArray(mainGroup)) {
-    pushWindow('primary', 'account', pickField(mainGroup, 'primary_window', 'primaryWindow'), 0, '主力')
-    pushWindow('primary', 'account', pickField(mainGroup, 'secondary_window', 'secondaryWindow'), 1, '主力')
+    pushWindow('primary', 'account', pickField(mainGroup, 'primary_window', 'primaryWindow'), 0, '')
+    pushWindow('primary', 'account', pickField(mainGroup, 'secondary_window', 'secondaryWindow'), 1, '')
   }
 
   const codeReviewGroup = pickField(source, 'code_review_rate_limit', 'codeReviewRateLimit')

--- a/lib/gateway-quotas.js
+++ b/lib/gateway-quotas.js
@@ -208,6 +208,22 @@ function retryAfterMs(response) {
   return Number.isFinite(date) ? Math.min(5000, Math.max(0, date - Date.now())) : 0
 }
 
+// CPA 是一个本地管理端点加上上游 Provider 的双跳链路。管理端或上游
+// 偶发过载时，只有这些暂态 HTTP 状态才适合重试；认证/策略/解析失败必须立刻报错。
+const RETRYABLE_GATEWAY_HTTP_STATUSES = new Set([408, 429, 500, 502, 503, 504])
+const GATEWAY_RESPONSE_ATTEMPTS = 2
+const GATEWAY_RETRY_DELAY_MS = 300
+
+function isRetryableGatewayStatus(status) {
+  return RETRYABLE_GATEWAY_HTTP_STATUSES.has(Number(status))
+}
+
+function gatewayRetryDelay(response) {
+  return retryAfterMs(response) || GATEWAY_RETRY_DELAY_MS
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 async function readJsonResponse(response, phase, { maxBytes = MAX_BODY_BYTES } = {}) {
   if (!response || typeof response.ok !== 'boolean') throw errorOf('CPA_RESPONSE_INVALID', `${phase} response is invalid`)
   if (!response.ok) throw responseStatusError(response, phase)
@@ -250,7 +266,7 @@ async function fetchManagement(source, path, managementKey, options = {}) {
     'Content-Type': 'application/json',
     'X-Management-Key': managementKey,
   }
-  for (let rateAttempt = 0; rateAttempt < 2; rateAttempt++) {
+  for (let attempt = 0; attempt < GATEWAY_RESPONSE_ATTEMPTS; attempt++) {
     let response
     try {
       response = await fetchWithRetry(url, { method: 'GET', headers, redirect: 'manual' }, {
@@ -261,14 +277,14 @@ async function fetchManagement(source, path, managementKey, options = {}) {
       throw errorOf('CPA_OUTER_HTTP_ERROR', 'management request failed', { status: 0 })
     }
     if (response.status >= 300 && response.status < 400) throw errorOf('CPA_REDIRECT_REFUSED', 'CPA redirect refused', { status: response.status })
-    if (response.status === 429 && rateAttempt === 0) {
-      const delay = retryAfterMs(response)
-      if (delay > 0) await new Promise(resolve => setTimeout(resolve, delay))
+    // 管理端临时过载/限流时按 Retry-After 或短退避再试一次。
+    if (isRetryableGatewayStatus(response.status) && attempt + 1 < GATEWAY_RESPONSE_ATTEMPTS) {
+      await sleep(gatewayRetryDelay(response))
       continue
     }
     return { payload: await readJsonResponse(response, path), serverVersion: headerValue(response.headers, 'x-cpa-version') }
   }
-  throw errorOf('CPA_OUTER_HTTP_ERROR', 'management request rate limited', { status: 429 })
+  throw errorOf('CPA_OUTER_HTTP_ERROR', 'management request failed', { status: 0 })
 }
 
 /** Resolve only the management key value, never returning it to callers' state. */
@@ -408,21 +424,40 @@ async function apiCall(source, managementKey, account, request, options = {}) {
   if (projectId && request.url.includes('cloudcode-pa')) {
     body.data = request.data || JSON.stringify({ project: projectId })
   }
-  let response
-  try {
-    response = await fetchWithRetry(endpoint(source, GATEWAY_MANAGEMENT_PATHS.apiCall), {
-      method: 'POST',
-      headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-Management-Key': managementKey },
-      body: JSON.stringify(body),
-      redirect: 'manual',
-    }, { attempts: 2, timeoutMs: 30_000, fetchImpl })
-  } catch (error) {
-    if (error?.code) throw error
-    throw errorOf('CPA_OUTER_HTTP_ERROR', 'CPA api-call failed')
+  for (let attempt = 0; attempt < GATEWAY_RESPONSE_ATTEMPTS; attempt++) {
+    let response
+    try {
+      response = await fetchWithRetry(endpoint(source, GATEWAY_MANAGEMENT_PATHS.apiCall), {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-Management-Key': managementKey },
+        body: JSON.stringify(body),
+        redirect: 'manual',
+      }, { attempts: 2, timeoutMs: 30_000, fetchImpl })
+    } catch (error) {
+      if (error?.code) throw error
+      throw errorOf('CPA_OUTER_HTTP_ERROR', 'CPA api-call failed')
+    }
+    if (response.status >= 300 && response.status < 400) throw errorOf('CPA_REDIRECT_REFUSED', 'CPA redirect refused', { status: response.status })
+    // api-call 是副作用闸门已校验的只读额度请求；仅对暂态管理端状态重放一次。
+    if (isRetryableGatewayStatus(response.status) && attempt + 1 < GATEWAY_RESPONSE_ATTEMPTS) {
+      await sleep(gatewayRetryDelay(response))
+      continue
+    }
+    try {
+      const envelope = await readJsonResponse(response, 'api-call')
+      return normalizeInnerEnvelope(envelope, 'api-call')
+    } catch (error) {
+      // CPA 把上游 HTTP 状态装进 JSON envelope。429/5xx 同样属于暂态，
+      // 但认证、策略与格式错误绝不重试。
+      if (error?.code === 'CPA_INNER_HTTP_ERROR' && isRetryableGatewayStatus(error.status)
+        && attempt + 1 < GATEWAY_RESPONSE_ATTEMPTS) {
+        await sleep(GATEWAY_RETRY_DELAY_MS)
+        continue
+      }
+      throw error
+    }
   }
-  if (response.status >= 300 && response.status < 400) throw errorOf('CPA_REDIRECT_REFUSED', 'CPA redirect refused', { status: response.status })
-  const envelope = await readJsonResponse(response, 'api-call')
-  return normalizeInnerEnvelope(envelope, 'api-call')
+  throw errorOf('CPA_OUTER_HTTP_ERROR', 'CPA api-call retry exhausted', { status: 0 })
 }
 
 async function queryApiAccount(source, managementKey, account, options = {}) {

--- a/test/verify.mjs
+++ b/test/verify.mjs
@@ -6358,6 +6358,33 @@ function m_costOf85(entry, tokens) {
   assert.deepEqual(successCalls.map(call => new URL(call.url).pathname), [GATEWAY_MANAGEMENT_PATHS.authFiles, GATEWAY_MANAGEMENT_PATHS.apiCall], 'only fixed management paths are used')
   assert.equal(successCalls.length, 2)
 
+  // CPA 是双跳路径:管理端 5xx 与管理端封装的上游 5xx 都可能是短暂波动。
+  // 两者各重试一次后应仍得到可用快照；认证等持久错误仍由下方用例确认不重试。
+  const transientCalls = []
+  let authAttempts = 0
+  let apiAttempts = 0
+  const transientFetch = async (url, init = {}) => {
+    const path = new URL(url).pathname
+    transientCalls.push(path)
+    if (path === GATEWAY_MANAGEMENT_PATHS.authFiles) {
+      authAttempts++
+      if (authAttempts === 1) return jsonResponse({ busy: true }, 503)
+      return jsonResponse({ auth_files: [{ auth_index: 'claude-auth-87', provider: 'anthropic', email: piiEmail }] })
+    }
+    if (path === GATEWAY_MANAGEMENT_PATHS.apiCall) {
+      apiAttempts++
+      if (apiAttempts === 1) return jsonResponse({ status_code: 503, body: '{}' })
+      return jsonResponse({ status_code: 200, body: JSON.stringify({ five_hour: { utilization: 38 } }) })
+    }
+    throw new Error(`unexpected transient gateway path: ${path}`)
+  }
+  const transientResult = await queryGatewayQuota(credentialContext, claudeSource, { fetchImpl: transientFetch })
+  assert.equal(transientResult.status, 'ok', 'temporary CPA failures retry to a valid quota snapshot')
+  assert.equal(transientResult.accounts[0].windows[0].percent, 38)
+  assert.equal(authAttempts, 2, 'management 503 is retried once')
+  assert.equal(apiAttempts, 2, 'enveloped upstream 503 is retried once')
+  assert.deepEqual(transientCalls, [GATEWAY_MANAGEMENT_PATHS.authFiles, GATEWAY_MANAGEMENT_PATHS.authFiles, GATEWAY_MANAGEMENT_PATHS.apiCall, GATEWAY_MANAGEMENT_PATHS.apiCall])
+
   const authFailureCalls = []
   const authFailureFetch = async (url, init = {}) => {
     authFailureCalls.push({ url, init })


### PR DESCRIPTION
## 问题

CLIProxyAPI 网关额度的刷新一会成功、一会失败。该链路是双跳：插件 → CPA 管理端 → 上游 Provider(Codex 等)。此前只有**网络层异常**(ECONNRESET 等)会自动重试；管理端或 CPA 封装的上游偶发返回 `429` / `5xx` 时，整个刷新立即判失败，下一个周期又恢复——表现即为"时好时坏"。

## 修复(`lib/gateway-quotas.js`)

- 对暂态 HTTP 状态 **`408 / 429 / 500 / 502 / 503 / 504`** 增加一次受控重试(优先遵从 `Retry-After`,上限 5s;否则退避 300ms):
  - `fetchManagement`:CPA 管理端响应(auth-files / workbuddy credits);
  - `apiCall`:管理端 JSON 信封里封装的**上游**状态(`CPA_INNER_HTTP_ERROR`)。
- **不重试**：`401/403` 认证失败、3xx 重定向(维持拒绝)、策略拦截、响应格式错误、Provider 解析错误——这些重试没有意义或违背取消意图。
- 重试对象仍是经过副作用硬闸(`FORBIDDEN_REQUEST_MARKERS`)校验后的**只读**额度请求，不会产生计费副作用。
- 顺带修一处显示问题(`lib/gateway-quota-adapters.js`):Codex 窗口标签「主力·5小时」→「5h」、「主力·每周」→「周」，窄侧边栏卡片不再竖排换行。

## 测试(`test/verify.mjs`)

新增回归：管理端 `503` 失败一次 + 封装的上游 `503` 失败一次后，重试恢复为有效快照(断言各恰好尝试 2 次且请求路径序列正确)；既有用例确认 `401`、重定向、畸形响应仍不重试。全量 `node test/verify.mjs` 通过。
