### PR TITLE
官方额度快照作为权威用量源

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1582,6 +1582,26 @@ function createService(ctx, ledger) {
     // SCNet 无 API 额度端点(issue #26):按官方 Credits 抵扣表对本地账本同步估算——
     // 纯本地计算开销可忽略,跳过缓存间隔,每次状态组装都随账本最新数据重算。
     if (id === 'scnet') {
+            let off = null
+      try {
+        const sp = join(resolveDshHome(), 'storages', 'cost-meter', 'scnet_official.json')
+        const o = JSON.parse(fs.readFileSync(sp, 'utf8'))
+        const u = Number(o.used); const t = Number(o.total)
+        if (Number.isFinite(u) && u >= 0 && Number.isFinite(t) && t > 0) off = { used: u, total: t, at: o.at }
+      } catch {}
+      if (off !== null) {
+        const pct = Math.min(100, Math.round((off.used / off.total) * 1000) / 10)
+        const fmt = n => Math.round(n).toLocaleString('en-US')
+        codingPlanCaches[id] = {
+          fetchedAt: Date.now(),
+          value: { status: 'ok', message: '', fetchedAt: Date.now(),
+            windows: {
+              monthly: { percent: pct, resetsAt: off.at ? new Date(off.at).toISOString() : '' },
+              credits: { resetsAt: '', text: `${fmt(off.used)} / ${fmt(off.total)} Credits(官方快照)` },
+            } },
+        }
+        return
+      }
       const result = scnetTokenPlanWindows(ledger.days ?? {}, config, Date.now())
       codingPlanCaches[id] = {
         fetchedAt: Date.now(),


### PR DESCRIPTION
### Problem
The SCNet Token Plan side panel shows a local-ledger-based estimate that is far off
official: the official console reported used=24,338.72/60,000 (40.6%) while the plugin
estimated 6,871/60,000 (11.5%). SCNet has no API-Key usage endpoint (usage only visible
in the logged-in console), and the plugin's local ledger only captures DSH-side usage —
the same sk-tp- key is consumed by other tools (e.g. Kimi Code), which the ledger never
sees, so the estimate structurally cannot match the official total.

### Change
In ensureCodingPlan('scnet'), before falling back to the local-ledger estimate, check for
an official snapshot file $DSH_HOME/storages/cost-meter/scnet_official.json written by an
external fetcher. If present and valid, use its used/total (the authoritative console value)
to build the panel windows, so the panel displays the official credits/percent instead of
the misleading estimate. If the file is absent/invalid, it falls back to the existing
ledger-based estimate (unchanged behaviour).