### PR TITLE
feat(pricing): 新增 gpt-6-astra token 定价

### DIFF
--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -109,6 +109,7 @@ export const DEFAULT_PEAK_WINDOWS = [
 export const DEFAULT_PROVIDER_PRICE_TABLE = {
   openai: {
     models: {
+      'gpt-6-astra': { input: 10, cachedInput: 1, output: 50, billingMode: 'flat', sourceUrl: 'https://opencode.ai/docs/zen', checkedAt: '2026-09-08', notes: '≤272K 档;超过 272K 按 $20/$75 计(缓存读 $2、写入 $25);缓存写入 $12.50' },
       'gpt-5.6-sol': { input: 2, cachedInput: 0.2, output: 10, billingMode: 'flat', sourceUrl: 'https://opencode.ai/docs/zen', checkedAt: '2026-08-25', notes: '≤272K 档;超过 272K 按 $4/$15 计(缓存读 $0.40、写入 $5);缓存写入 $2.50;目录标注 2026-09-18 前为五折促销价(issue #58)' },
       'gpt-5.6-terra': { input: 2, cachedInput: 0.2, output: 12, billingMode: 'flat', sourceUrl: 'https://opencode.ai/docs/zen', checkedAt: '2026-08-17', notes: '≤272K 档;超过 272K 按 $4/$18 计;缓存写入 $2.50' },
       'gpt-5.6-luna': { input: 0.2, cachedInput: 0.02, output: 1.2, billingMode: 'flat', sourceUrl: 'https://opencode.ai/docs/zen', checkedAt: '2026-08-17', notes: '≤272K 档;超过 272K 按 $0.40/$1.80 计;缓存写入 $0.25' },
@@ -285,6 +286,7 @@ export const DEFAULT_PROVIDER_PRICE_TABLE = {
 export const PROVIDER_MODEL_FAMILIES = {
   deepseek: { 'deepseek-v4-flash': 'DeepSeek v4', 'deepseek-v4-pro': 'DeepSeek v4', 'deepseek-v4-flash-vision-exp': 'DeepSeek v4', 'deepseek-v4.1-flash': 'DeepSeek v4.1' },
   openai: {
+    'gpt-6-astra': 'GPT-6 Astra',
     'gpt-5.6-sol': 'GPT-5.6', 'gpt-5.6-terra': 'GPT-5.6', 'gpt-5.6-luna': 'GPT-5.6',
     'gpt-5.5': 'GPT-5.5', 'gpt-5.5-pro': 'GPT-5.5',
     'gpt-5.4': 'GPT-5.4', 'gpt-5.4-pro': 'GPT-5.4', 'gpt-5.4-mini': 'GPT-5.4', 'gpt-5.4-nano': 'GPT-5.4',


### PR DESCRIPTION
## 功能

拓展价格表新增 **GPT 6 Astra**(`gpt-6-astra`)的 token 定价,来源
[opencode.ai/docs/zen](https://opencode.ai/docs/zen)(2026-09-08 核对):

| 档位 | 输入 | 输出 | 缓存读 | 缓存写入 |
|---|---|---|---|---|
| ≤272K tokens | \$10 | \$50 | \$1 | \$12.50 |
| >272K tokens | \$20 | \$75 | \$2 | \$25 |

- `DEFAULT_PROVIDER_PRICE_TABLE.openai.models` 新增 `gpt-6-astra` 条目
  (`billingMode: 'flat'`,>272K 档位按既有惯例记录于 notes);
- `PROVIDER_MODEL_FAMILIES.openai` 新增 `GPT-6 Astra` 家族分组。

## 测试

`node test/verify.mjs` 全部通过(基线 v1.7.15 / 43d552e,含千问余额、
网关重试、#108/#109 渠道隔离、#118 简化侧栏等既有回归)。
