### PR TITLE
fix: 宿主不支持 ignorable 时不再写入原生搜索会话事件（避免整份会话日志不可读）

### DIFF
--- a/lib/native-search-billing.js
+++ b/lib/native-search-billing.js
@@ -244,6 +244,25 @@ export function nativeSearchReconcile(ledger, locale, reconcile) {
   return { ok: false, message: [reconcile?.message, message].filter(Boolean).join('\n') }
 }
 
+/**
+ * 宿主能否把信封的 `ignorable` 标记持久化。
+ *
+ * DSH 的会话日志读取端对未知事件类型 fail-closed：只有带 `ignorable: true` 的
+ * 未知事件会被跳过，否则整份日志拒绝解析（该会话历史从此打不开）。本插件的
+ * `cost-meter/native-search-usage` 正是宿主不认识的类型，因此只有当宿主
+ * `Session.append` 确实支持写入该标记时才能安全落盘。
+ * 探测不到（老宿主只接受 surfaceOp / sourceEventSeqs）时不写会话事件：
+ * 费用仍由 account 记入插件自己的账本，但不会把会话日志写坏。
+ */
+export function appendPersistsIgnorable(session) {
+  try {
+    if (typeof session?.append !== 'function') return false
+    return /\bignorable\b/.test(Function.prototype.toString.call(session.append))
+  } catch { return false }
+}
+
+let ignorableUnsupportedWarned = false
+
 /** 可选 web 服务：未安装搜索能力时不影响插件启动。 */
 export function installNativeSearchBilling(ctx, ledger) {
   if (monitors.has(ledger)) return
@@ -253,7 +272,19 @@ export function installNativeSearchBilling(ctx, ledger) {
       const usage = event.usage
       ledger.account({ input: usage.inputTokens, output: usage.outputTokens, cacheRead: usage.cacheReadTokens, cacheWrite: usage.cacheWriteTokens, reasoning: usage.reasoningTokens }, event.model, session?.id, event.startedAtMs, event.provider)
     },
-    record(session, event) { session.append(NATIVE_SEARCH_USAGE_EVENT, event) },
+    // 宿主不支持 ignorable 标记时放弃写会话事件：写入未知类型会让整份会话
+    // 日志在下次加载时被拒（见 appendPersistsIgnorable）。此时费用明细只留在
+    // 插件账本里，全局/当日/历史统计不受影响。
+    record(session, event) {
+      if (!appendPersistsIgnorable(session)) {
+        if (!ignorableUnsupportedWarned) {
+          ignorableUnsupportedWarned = true
+          console.warn('[dsh-cost-meter] 当前宿主不支持在事件信封写入 ignorable 标记，已跳过原生搜索用量会话事件以避免会话日志不可读；费用仍记入插件账本。')
+        }
+        return
+      }
+      session.append(NATIVE_SEARCH_USAGE_EVENT, event, { ignorable: true })
+    },
     uncovered: (event) => coverage.add(event),
   })
   monitors.set(ledger, { coverage })

--- a/test/native-search-billing.mjs
+++ b/test/native-search-billing.mjs
@@ -5,7 +5,8 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gzipSync } from 'node:zlib'
-import { createNativeSearchBilling, createSearchCoverage, nativeSearchUsage, installNativeSearchBilling, nativeSearchReconcile, NATIVE_SEARCH_USAGE_EVENT, isNativeSearchUsageEvent } from '../lib/native-search-billing.js'
+import { channel } from 'node:diagnostics_channel'
+import { createNativeSearchBilling, createSearchCoverage, nativeSearchUsage, installNativeSearchBilling, nativeSearchReconcile, NATIVE_SEARCH_USAGE_EVENT, isNativeSearchUsageEvent, appendPersistsIgnorable } from '../lib/native-search-billing.js'
 import { Ledger, sanitizeConfig, localDayKey } from '../lib/store.js'
 import { replaySessionRecords } from '../lib/backfill.js'
 import { __testProjection } from '../lib/index.js'
@@ -262,5 +263,72 @@ function harness(overrides = {}) {
     assert.equal(web.search, original, 'web 服务卸载恢复原方法')
     assert.equal(NATIVE_SEARCH_USAGE_EVENT, 'cost-meter/native-search-usage')
   } finally { rmSync(root, { recursive: true, force: true }) }
+}
+// 宿主能力探测：宿主读取端对未知事件类型 fail-closed，只跳过带信封 ignorable 的未知事件。
+// 因此只有宿主确实能把该标记持久化时才写会话事件；探测不到时必须不落盘（否则该会话重启后
+// 整份日志被 validateStoredEvents 拒绝），但计费（account）照常。新宿主支持后自动恢复落盘。
+{
+  const root = mkdtempSync(join(tmpdir(), 'cm-search-ignorable-'))
+  const warnings = []
+  const originalWarn = console.warn
+  try {
+    assert.equal(appendPersistsIgnorable(undefined), false)
+    assert.equal(appendPersistsIgnorable({}), false)
+    assert.equal(appendPersistsIgnorable({ append: 1 }), false)
+    assert.equal(appendPersistsIgnorable({ append: () => {} }), false, '无该标记的旧宿主不得被误判为支持')
+    // 0.1.5-rc.1 的编译形态：Session.append 只从 opts[0] 读 surfaceOp / sourceEventSeqs。
+    const oldHostSession = {
+      id: 'old-host',
+      rows: [],
+      append(type, data, ...opts) {
+        const surfaceOpts = opts[0]
+        const surfaceMetadata = {
+          ...surfaceOpts?.sourceEventSeqs === undefined ? {} : { sourceEventSeqs: surfaceOpts.sourceEventSeqs },
+          ...surfaceOpts?.surfaceOp === undefined ? {} : { surfaceOp: surfaceOpts.surfaceOp },
+        }
+        this.rows.push({ type, data, ...surfaceMetadata })
+        return this.rows.at(-1)
+      },
+    }
+    // 未来宿主形态：opts.ignorable 会被写进信封。
+    const newHostSession = {
+      id: 'new-host',
+      rows: [],
+      append(type, data, ...opts) {
+        const ignorable = opts[0]?.ignorable === true ? { ignorable: true } : {}
+        this.rows.push({ type, data, ...ignorable })
+        return this.rows.at(-1)
+      },
+    }
+    assert.equal(appendPersistsIgnorable(oldHostSession), false, '旧宿主 append 无法写入 ignorable')
+    assert.equal(appendPersistsIgnorable(newHostSession), true, '可写入 ignorable 的宿主被识别')
+
+    const official = 'https://api.deepseek.com'
+    const drive = (request) => {
+      channel('undici:request:create').publish({ request })
+      channel('undici:request:headers').publish({ request, response: { statusCode: 200, headers: [] } })
+      channel('undici:request:bodyChunkReceived').publish({ request, chunk: Buffer.from(JSON.stringify(response())) })
+      channel('undici:request:trailers').publish({ request })
+    }
+    console.warn = (...args) => warnings.push(args.join(' '))
+    for (const [label, session, expectedRows] of [['旧宿主', oldHostSession, 0], ['新宿主', newHostSession, 1]]) {
+      const effects = [], accounts = []
+      const web = { async search(request) { drive({ method: 'POST', origin: official, path: '/anthropic/v1/messages' }); return request } }
+      const ctx = { effect: fn => effects.push(fn()), get: name => name === 'agents' ? { currentInitiator: () => ({ session }) } : undefined, inject: (_, fn) => fn({ web, get: name => ctx.get(name), effect: fn => effects.push(fn()) }) }
+      const ledger = { path: join(root, `${label}.json`), account: (...args) => accounts.push(args) }
+      installNativeSearchBilling(ctx, ledger)
+      await web.search({ query: 'synthetic' })
+      for (const dispose of effects.reverse()) dispose()
+      assert.equal(accounts.length, 1, `${label}: 原生搜索用量照常入账`)
+      assert.equal(accounts[0][2], session.id, `${label}: 入账带上会话 id`)
+      assert.equal(session.rows.length, expectedRows, `${label}: 会话事件落盘数符合宿主能力`)
+      for (const row of session.rows) assert.equal(row.type, NATIVE_SEARCH_USAGE_EVENT)
+      if (expectedRows === 1) assert.equal(session.rows[0].ignorable, true, '可持久化宿主下信封带 ignorable')
+    }
+    assert.equal(warnings.length, 1, '仅对不支持 ignorable 的宿主告警一次')
+  } finally {
+    console.warn = originalWarn
+    rmSync(root, { recursive: true, force: true })
+  }
 }
 console.log('原生搜索计费回归通过')


### PR DESCRIPTION
## 问题

`lib/native-search-billing.js` 的落库回调直接把插件自有的未知事件类型写入会话日志：

```js
record(session, event) { session.append(NATIVE_SEARCH_USAGE_EVENT, event) }
```

而宿主的会话日志读取端对未知事件类型是 fail-closed：`validateStoredEvents`（`packages/session/session-persistence/src/storage-contract.ts`）只跳过带信封 `ignorable: true` 的未知事件，否则拒绝解释**整份**日志。宿主写入路径不校验事件类型，所以写入时没有任何提示，只有在重启后重新从磁盘回放日志时才暴露：

```
failed to observe session "session-…": session "session-…" contains event type
"cost-meter/native-search-usage" (seq 256) unknown to this harness and not marked ignorable;
refusing to interpret the log — it was likely written by a newer harness
```

结果是：只要会话里成功计费过一次 DeepSeek 官方原生搜索，该会话在重启后就再也打不开。

关联： #132 #133

## 本 PR 的做法

新增 `appendPersistsIgnorable(session)` 能力探测：**只有宿主确实能把信封 `ignorable` 标记持久化时**才写入该会话事件；探测不到（当前宿主，见下）时跳过写入，并只发一次 `console.warn`。

```js
record(session, event) {
  if (!appendPersistsIgnorable(session)) { /* 跳过，账本计费不受影响 */ return }
  session.append(NATIVE_SEARCH_USAGE_EVENT, event, { ignorable: true })
}
```

为什么不直接传 `ignorable`：当前宿主（0.1.5-rc.1，本机实测；`upstream.json` 也把 stable/beta 都钉在 `sourceVersion 0.1.5-rc.1`）的 `Session.append(type, data, ...opts)` **只**从 `opts[0]` 读取 `surfaceOp` / `sourceEventSeqs`，没有任何入口能写入 `ignorable`：

```js
append(type, data, ...opts) {
  const surfaceOpts = opts[0];
  const surfaceMetadata = {
    ...surfaceOpts?.sourceEventSeqs === void 0 ? {} : { sourceEventSeqs: surfaceOpts.sourceEventSeqs },
    ...surfaceOpts?.surfaceOp === void 0 ? {} : { surfaceOp: surfaceOpts.surfaceOp }
  };
  ...
}
```

因此插件在现有 API 下「写不出」这个兼容标记。本 PR 的行为与 #132 的建议方向一致（宿主不支持时不再把纯计量记录写进会话日志），但保留了将来宿主支持该标记后**自动恢复**会话日志写入的能力，不需要再发一版插件。

`account()` 逻辑完全未改：原生搜索费用仍照常写入插件账本 `ledger.json`（含 sessionId），当日/历史统计不受影响。

## 验证

基线：npm 发布版 1.7.21 与 `master` 上该文件字节相同（sha256 `2658ffb4…`）。

1. **精确差分**：改动后的 `lib/native-search-billing.js` == 发布版 1.7.21 + 恰好两处改动（新增探测函数、改写 `record`）；`session.append` 调用点仍只有 1 处；其余文件字节不变。
2. **探测单测**：对从 app.asar 提取的**真实编译** `Session.append` 源码探测为 `false`；对可写 `ignorable` 的宿主形态为 `true`；对 `undefined` / 非函数 / 普通箭头函数均为 `false`（失败方向安全）。
3. **端到端功能测试**（用真实 `node:diagnostics_channel` 的 undici 事件驱动本模块真实代码）：
   - 当前宿主：`ledger.account` 调用 1 次（五桶、model、sessionId、provider、时间戳全部正确），`session.append` 调用 **0 次**；
   - 支持该标记的宿主：`ledger.account` 仍 1 次，`session.append` 1 次且带 `{ ignorable: true }`。
4. **仓库自检**：`node --check lib/native-search-billing.js` 通过；`node test/verify.mjs` 在改动前后均 `[ok] 全部验证通过`（含新加的 case）。`test/native-search-billing.mjs` 新增两种宿主形态的用例：入账次数、会话事件落盘数、信封 `ignorable`、以及仅对不支持宿主告警一次。
5. **用例有效性**：把探测函数临时改成恒为 `true`（保留导出、仅回退行为）后，新用例以 `AssertionError: 无该标记的旧宿主不得被误判为支持` 失败；恢复补丁后全量通过 —— 说明用例覆盖的是行为本身，不是导入错误。
6. 本补丁在 `master` 上 `git apply` 检查通过，apply 结果与上述已验证文件字节一致。

## 改动文件

- `lib/native-search-billing.js`（探测函数 + `record` 守卫）
- `test/native-search-billing.mjs`（新增用例与 `node:diagnostics_channel` 导入）

## 备选方案

如果你更希望彻底不再把计量记录写进会话日志（即无条件 no-op），我可以把 `record()` 改成无条件跳过 —— 更简单，但宿主将来提供该标记入口后也无法自动恢复，需要再发一版。

## 影响与取舍

- 修复：当前宿主上不再产生不可读会话日志；
- 取舍：宿主不支持该标记期间，「本会话」投影少这几条原生搜索的 token/费用明细（账本/当日/历史不受影响）。

---

### English summary

`lib/native-search-billing.js` appends the plugin's own event type (`cost-meter/native-search-usage`) to the session log. The harness read path (`validateStoredEvents`) is fail-closed for unknown event types unless the stored envelope carries `ignorable: true`, while this host build's `Session.append(type, data, ...opts)` only accepts `surfaceOp` / `sourceEventSeqs` — so no plugin can set that marker through the public API, and every session that records native-search usage becomes unloadable after a restart.

This PR probes host support (`appendPersistsIgnorable`) and only writes the session event when the marker can actually be persisted; otherwise it skips the write (ledger accounting is untouched) and warns once. On a host that gains `ignorable` support the session-log write resumes automatically. Verified by exact-diff against the published 1.7.21, probe unit tests against the real compiled `Session.append`, and an end-to-end `diagnostics_channel` test proving `ledger.account` still runs while `session.append` is not called on this host. Refs #132 #133.
